### PR TITLE
Mesh reduction

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+open3d
 pyglet<=1.5.17
 pyyaml
 scikit-robot

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ from setuptools import find_packages
 from setuptools import setup
 
 
-version = "0.0.4"
+version = "0.0.5"
 
 
 if sys.argv[-1] == 'release':

--- a/tests/urdfeus_tests/test_urdfeus.py
+++ b/tests/urdfeus_tests/test_urdfeus.py
@@ -17,3 +17,5 @@ class TestURDF2EUS(unittest.TestCase):
         urdf2eus(fetch_urdfpath(),
                  osp.join(data_dir, 'fetch.yaml'))
         urdf2eus(pr2_urdfpath())
+
+        urdf2eus(pr2_urdfpath(), simplify_vertex_clustering_voxel_size=0.001)

--- a/urdfeus/apps/mesh2eus.py
+++ b/urdfeus/apps/mesh2eus.py
@@ -11,9 +11,19 @@ def main():
                         help='Input mesh file path')
     parser.add_argument('output_euslisp_path', type=str,
                         help='Output Euslisp path')
+    parser.add_argument(
+        '--simplify-vertex-clustering-voxel-size', '--voxel-size',
+        default=None,
+        type=float,
+        help='Specifies the voxel size for the simplify_vertex_clustering'
+        ' function in open3d. When this value is provided, '
+        'it is used as the voxel size in the function to perform '
+        'mesh simplification. This process reduces the complexity'
+        ' of the mesh by clustering vertices within the specified voxel size.')
     args = parser.parse_args()
     with open(args.output_euslisp_path, 'w') as f:
         mesh2eus(args.input_mesh_path,
+                 args.simplify_vertex_clustering_voxel_size,
                  fp=f)
 
 

--- a/urdfeus/apps/urdf2eus.py
+++ b/urdfeus/apps/urdf2eus.py
@@ -13,10 +13,20 @@ def main():
     parser.add_argument('--yaml-path', type=str,
                         default=None,
                         help='Config yaml path')
+    parser.add_argument(
+        '--simplify-vertex-clustering-voxel-size', '--voxel-size',
+        default=None,
+        type=float,
+        help='Specifies the voxel size for the simplify_vertex_clustering'
+        ' function in open3d. When this value is provided, '
+        'it is used as the voxel size in the function to perform '
+        'mesh simplification. This process reduces the complexity'
+        ' of the mesh by clustering vertices within the specified voxel size.')
     args = parser.parse_args()
     with open(args.output_euslisp_path, 'w') as f:
         urdf2eus(args.input_urdf_path,
                  args.yaml_path,
+                 args.simplify_vertex_clustering_voxel_size,
                  fp=f)
 
 

--- a/urdfeus/mesh2eus.py
+++ b/urdfeus/mesh2eus.py
@@ -6,7 +6,8 @@ from urdfeus.templates.urdf_template import urdf_template
 from urdfeus.urdf2eus import urdf2eus
 
 
-def mesh2eus(mesh_path, fp=sys.stdout, mesh_name=None):
+def mesh2eus(mesh_path, simplify_vertex_clustering_voxel_size=None,
+             fp=sys.stdout, mesh_name=None):
     if mesh_name is None:
         mesh_name, _ = osp.splitext(osp.basename(mesh_path))
     collision_mesh_filepath = osp.abspath(mesh_path)
@@ -23,4 +24,5 @@ def mesh2eus(mesh_path, fp=sys.stdout, mesh_name=None):
         temp.write(formatted_urdf.encode('utf-8'))
         temp.seek(0)
         urdf2eus(temp_urdf_path,
+                 simplify_vertex_clustering_voxel_size,
                  fp=fp)

--- a/urdfeus/mesh_utils.py
+++ b/urdfeus/mesh_utils.py
@@ -1,4 +1,5 @@
 import numpy as np
+import open3d
 
 
 def split_mesh_by_face_color(mesh):
@@ -29,3 +30,15 @@ def split_mesh_by_face_color(mesh):
         submeshes.append(submesh)
 
     return submeshes
+
+
+def to_open3d(mesh):
+    o3d_mesh = open3d.geometry.TriangleMesh()
+    o3d_mesh.vertices = open3d.utility.Vector3dVector(np.array(mesh.vertices))
+    o3d_mesh.triangles = open3d.utility.Vector3iVector(np.array(mesh.faces))
+
+    # Convert vertex colors from RGBA to RGB and normalize the color values
+    # Use NumPy slicing and broadcasting for efficient conversion
+    vertex_colors = np.array(mesh.visual.vertex_colors)[:, :3] / 255.0
+    o3d_mesh.vertex_colors = open3d.utility.Vector3dVector(vertex_colors)
+    return o3d_mesh

--- a/urdfeus/urdf2eus.py
+++ b/urdfeus/urdf2eus.py
@@ -185,7 +185,13 @@ def print_mesh(link, fp=sys.stdout):
             vertices = np.array(input_mesh.vertices)
             vertices = link.inverse_transformation().transform_vector(vertices)
             vertices = meter2millimeter * vertices
-            print(' '.join(map(str, vertices.reshape(-1))), end='', file=fp)
+
+            # Modified the vertex printing format to reduce mesh file size, considering the unit is in millimeters (mm).  # NOQA
+            # Since the coordinates are in mm, having them formatted to just one decimal place is sufficiently precise for most applications.  # NOQA
+            # This change not only preserves the necessary precision for mm-scale measurements but also effectively compresses the data,  # NOQA
+            # resulting in a smaller file size due to reduced numerical precision in the vertex coordinates.  # NOQA
+            print(' '.join(map(lambda x: '{0:.1f}'.format(x), vertices.reshape(-1))),
+                  end='', file=fp)
             print(")) mat))", end="", file=fp)
             # TODO(someone) normal
             print(")", end='', file=fp)


### PR DESCRIPTION
Enable mesh reduction option.

Modified the vertex printing format to reduce mesh file size, considering the unit is in millimeters (mm). 
Since the coordinates are in mm, having them formatted to just one decimal place is sufficiently precise for most applications. 
This change not only preserves the necessary precision for mm-scale measurements but also effectively compresses the data,
resulting in a smaller file size due to reduced numerical precision in the vertex coordinates.