### PR TITLE
Add :all-links method to euscollada-robot class

### DIFF
--- a/urdfeus/templates/euscollada-robot.l
+++ b/urdfeus/templates/euscollada-robot.l
@@ -97,7 +97,8 @@
   ;; that are not explicitly listed in the YAML configuration file.
   (:all-links
    ()
-   (send self :get-links-recursive (car (send self :descendants))))
+   (let ((root-link (car (last (send self :descendants)))))
+     (send self :get-links-recursive root-link)))
   (:get-links-recursive
    (parent-link)
    (when parent-link


### PR DESCRIPTION
In [previous pull request](https://github.com/iory/urdfeus/pull/19), I was getting the root link with `(car (send self :descendants))`.

However, looking at the [assoc function](https://github.com/euslisp/EusLisp/blob/71a2528e72fe3622b8d807103d8057f79433b979/lisp/l/coordinates.l#L333-L342), it seems that child links are pushed to the descendants list using `(push child descendants)`.

Therefore, I've changed the code to get the root link with `(car (last (send self :descendants)))`.