### PR TITLE
Added :get-link method to get links connected by fixed joints

### DIFF
--- a/urdfeus/templates/euscollada-robot.l
+++ b/urdfeus/templates/euscollada-robot.l
@@ -99,6 +99,9 @@
    ()
    (let ((root-link (car (last (send self :descendants)))))
      (send self :get-links-recursive root-link)))
+  (:get-link
+    (link-name)
+    (find-if #'(lambda (link) (equal (send link :name) link-name)) (send self :all-links)))
   (:get-links-recursive
    (parent-link)
    (when parent-link


### PR DESCRIPTION
The method :link can not get links that are connected by fixed joints.
Newly added method :get-link can get all links by it's name.