### PR TITLE
Fix pqp-collision-distance not working correctly with robot object

### DIFF
--- a/tests/urdfeus_tests/test_console_scripts.py
+++ b/tests/urdfeus_tests/test_console_scripts.py
@@ -1,5 +1,6 @@
 import os
 import os.path as osp
+import shutil
 import subprocess
 import tempfile
 import unittest
@@ -15,6 +16,12 @@ def run_command(cmd):
     kwargs["stderr"] = subprocess.PIPE
     result = subprocess.run(cmd, shell=True, **kwargs)
     return result
+
+
+def is_euslisp_available():
+    """Check if roseus/euslisp is available."""
+    result = run_command("which roseus")
+    return result.returncode == 0
 
 
 class TestConsoleScripts(unittest.TestCase):
@@ -98,5 +105,93 @@ class TestConsoleScripts(unittest.TestCase):
                 self.assertIn("Invalid robot name", result.stderr.decode())
 
         # Clean up
-        import shutil
         shutil.rmtree(temp_dir, ignore_errors=True)
+
+    @unittest.skipUnless(is_euslisp_available(), "roseus not available")
+    def test_pqp_collision_distance_with_robot_object(self):
+        """Test that pqp-collision-distance works correctly with robot object.
+
+        This test verifies that collision detection uses the actual mesh geometry
+        rather than the default 10x10x10mm cube from collada-body.
+        The test performs edge-case collision checks at the mesh boundary.
+        """
+        target_mesh = osp.join(
+            osp.dirname(self.urdfpath), "meshes", "base_link.dae")
+        temp_dir = tempfile.mkdtemp()
+        output_eus_path = osp.join(temp_dir, "test_collision.l")
+
+        try:
+            # Generate euslisp file from mesh
+            result = run_command(f"mesh2eus {target_mesh} {output_eus_path}")
+            self.assertEqual(result.returncode, 0,
+                             f"mesh2eus failed: {result.stderr.decode()}")
+
+            # Find the robot creation function name from generated file
+            # mesh2eus uses mesh internal name, not filename
+            robot_func_name = None
+            with open(output_eus_path) as f:
+                for line in f:
+                    if line.strip().startswith('(defun ') and 'jacobian' not in line:
+                        # Extract function name: (defun NAME () ...)
+                        robot_func_name = line.split()[1]
+                        break
+
+            self.assertIsNotNone(robot_func_name,
+                                 "Could not find robot function in generated file")
+
+            # Run collision test using external euslisp template
+            # Pass parameters via environment variables
+            test_template = osp.join(data_dir, "test_pqp_collision.l")
+            env_vars = f"EUS_FILE_PATH={output_eus_path} ROBOT_FUNC_NAME={robot_func_name}"
+            result = run_command(f"{env_vars} roseus {test_template}")
+
+            # Parse results
+            stdout = result.stdout.decode()
+            self.assertEqual(result.returncode, 0,
+                             f"roseus failed: {result.stderr.decode()}\n{stdout}")
+
+            # Find result line
+            result_line = None
+            for line in stdout.split('\n'):
+                if line.startswith('RESULT:'):
+                    result_line = line.replace('RESULT:', '')
+                    break
+
+            self.assertIsNotNone(result_line,
+                                 f"No result found in output: {stdout}")
+
+            values = result_line.split(',')
+            self.assertEqual(len(values), 7,
+                             f"Unexpected result format: {result_line}")
+
+            dist_outside_robot = float(values[0])
+            dist_outside_link = float(values[1])
+            dist_center_robot = float(values[2])
+            dist_center_link = float(values[3])
+            dist_large_robot = float(values[4])
+            dist_large_link = float(values[5])
+            robot_has_pqpmodel = int(values[6])
+
+            # Assertions
+            # 1. Robot should have pqpmodel (our fix)
+            self.assertEqual(robot_has_pqpmodel, 1,
+                             "Robot object should have pqpmodel set")
+
+            # 2. Cube far outside should have positive distance
+            self.assertGreater(dist_outside_robot, 0,
+                               "Cube outside mesh should have positive distance")
+            self.assertGreater(dist_outside_link, 0,
+                               "Cube outside mesh should have positive distance")
+
+            # 3. MOST IMPORTANT: robot and link should give SAME results
+            # This is the main fix - previously robot used 10x10x10 cube
+            # which gave different (incorrect) results
+            self.assertEqual(dist_outside_robot, dist_outside_link,
+                             "Robot and link should give same result for outside cube")
+            self.assertEqual(dist_center_robot, dist_center_link,
+                             "Robot and link should give same result for center cube")
+            self.assertEqual(dist_large_robot, dist_large_link,
+                             "Robot and link should give same result for large cube")
+
+        finally:
+            shutil.rmtree(temp_dir, ignore_errors=True)

--- a/tests/urdfeus_tests/test_pqp_collision.l
+++ b/tests/urdfeus_tests/test_pqp_collision.l
@@ -1,0 +1,80 @@
+;; Test template for pqp-collision-distance with robot object
+;; This file is used by test_console_scripts.py
+;;
+;; Usage:
+;;   EUS_FILE_PATH=/path/to/model.l ROBOT_FUNC_NAME=robot_name roseus test_pqp_collision.l
+;;
+;; Verifies that pqp-collision-distance returns the same results
+;; whether called with robot object or individual links.
+
+(defun run-collision-test (eus-file-path robot-func-name)
+  (load eus-file-path)
+  (setq robot (funcall (intern (string-upcase robot-func-name) *package*)))
+  (setq link0 (car (send robot :links)))
+
+  ;; Get bounding box from glvertices
+  (setq bd (car (send link0 :bodies)))
+  (setq glv (bd . gl::aglvertices))
+  (setq mesh-list (glv . gl::mesh-list))
+
+  ;; Calculate bounding box
+  (let ((min-x 1e10) (max-x -1e10)
+        (min-y 1e10) (max-y -1e10)
+        (min-z 1e10) (max-z -1e10))
+    (dolist (mesh mesh-list)
+      (let ((verts-array (cadr (assoc :vertices mesh))))
+        (when verts-array
+          (dotimes (i (car (array-dimensions verts-array)))
+            (let ((x (aref verts-array i 0))
+                  (y (aref verts-array i 1))
+                  (z (aref verts-array i 2)))
+              (setq min-x (min min-x x) max-x (max max-x x))
+              (setq min-y (min min-y y) max-y (max max-y y))
+              (setq min-z (min min-z z) max-z (max max-z z)))))))
+
+    ;; Test 1: Cube placed far outside mesh -> should NOT collide
+    (setq cube-outside (make-cube 10 10 10))
+    (send cube-outside :locate (float-vector (+ max-x 1000) 0 0) :world)
+    (send cube-outside :make-pqpmodel :fat 0)
+    (setq dist-outside-robot (car (pqp-collision-distance robot cube-outside)))
+    (setq dist-outside-link (car (pqp-collision-distance link0 cube-outside)))
+
+    ;; Test 2: Cube at mesh center -> test consistency between robot and link
+    (setq center-x (/ (+ min-x max-x) 2.0))
+    (setq center-y (/ (+ min-y max-y) 2.0))
+    (setq center-z (/ (+ min-z max-z) 2.0))
+    (setq cube-center (make-cube 10 10 10))
+    (send cube-center :locate (float-vector center-x center-y center-z) :world)
+    (send cube-center :make-pqpmodel :fat 0)
+    (setq dist-center-robot (car (pqp-collision-distance robot cube-center)))
+    (setq dist-center-link (car (pqp-collision-distance link0 cube-center)))
+
+    ;; Test 3: Large cube covering the entire mesh
+    (setq size-x (- max-x min-x))
+    (setq size-y (- max-y min-y))
+    (setq size-z (- max-z min-z))
+    (setq cube-large (make-cube (* 2 size-x) (* 2 size-y) (* 2 size-z)))
+    (send cube-large :locate (float-vector center-x center-y center-z) :world)
+    (send cube-large :make-pqpmodel :fat 0)
+    (setq dist-large-robot (car (pqp-collision-distance robot cube-large)))
+    (setq dist-large-link (car (pqp-collision-distance link0 cube-large)))
+
+    ;; Verify robot has pqpmodel set (our fix)
+    (setq robot-has-pqpmodel (if (get robot :pqpmodel) 1 0))
+
+    ;; Output results in CSV format for Python to parse
+    (format t "RESULT:~A,~A,~A,~A,~A,~A,~A~%"
+            dist-outside-robot
+            dist-outside-link
+            dist-center-robot
+            dist-center-link
+            dist-large-robot
+            dist-large-link
+            robot-has-pqpmodel)))
+
+;; Main: get parameters from environment variables and run test
+(let ((eus-file-path (unix:getenv "EUS_FILE_PATH"))
+      (robot-func-name (unix:getenv "ROBOT_FUNC_NAME")))
+  (when (and eus-file-path robot-func-name)
+    (run-collision-test eus-file-path robot-func-name)
+    (exit 0)))

--- a/urdfeus/templates/euscollada-robot.l
+++ b/urdfeus/templates/euscollada-robot.l
@@ -24,14 +24,17 @@
                                         (m* (send (car links) :worldrot)
                                             (l . inertia-tensor)))))))
    (send-super :init-ending)
-   (send self :make-collision-model-for-links)
-   ;;
+   ;; Set up child-link relationships for fixed joints (not in joint-list)
+   ;; Must be done BEFORE :make-collision-model-for-links because :all-links
+   ;; traverses child-links to find all links in the hierarchy
    (dolist (j (mapcan #'(lambda (x) (if (and (derivedp (cdr x) joint)
                                              (not (memq (cdr x) (send self :joint-list))))
                                         (list (cdr x)))) (send self :slots)))
      (send (send j :child-link) :add-joint j)
      (send (send j :child-link) :add-parent-link (send j :parent-link))
-     (send (send j :parent-link) :add-child-links (send j :child-link))))
+     (send (send j :parent-link) :add-child-links (send j :child-link)))
+   ;; Use :all-links to include links not in :links (e.g., fixed joint links)
+   (send self :make-collision-model-for-links :links (send self :all-links)))
   (:change-visual
    (&optional (visual :convex))
    (dolist (lk (send self :links))

--- a/urdfeus/templates/euscollada-robot.l
+++ b/urdfeus/templates/euscollada-robot.l
@@ -65,33 +65,51 @@
   ;; make collision model from faces or gl-vertices
   (:make-collision-model-for-links
    (&key (fat 0) (collision-func 'pqp-collision-check) ((:links ls) (send self :links)))
-   (dolist (ll ls)
-     (let (fs glv usefs)
-       (dolist (bd (send ll :bodies))
-         (if (derivedp bd collada-body)
-             (push (send bd :glvertices) glv)
-           (push (send bd :faces) fs)))
-       (setq fs (flatten fs))
-       (cond
-        ((and (not fs) glv) ;; if there is no faces, use glvertices for creating pqpmodel
-         (setq usefs (instance gl::glvertices :init nil))
-         (send usefs :transform (send ll :worldcoords))
-         (send usefs :append-glvertices glv)
-         (let ((m (send usefs (read-from-string
-                               (format nil ":make-~Amodel"
-                                       (string-right-trim "-COLLISION-CHECK" (string collision-func))))
+   (let (all-glv)  ;; collect all glvertices for robot pqpmodel
+     (dolist (ll ls)
+       (let (fs glv usefs collada-bodies)
+         (dolist (bd (send ll :bodies))
+           (if (derivedp bd collada-body)
+               (progn
+                 (push (send bd :glvertices) glv)
+                 (push bd collada-bodies))
+             (push (send bd :faces) fs)))
+         (setq fs (flatten fs))
+         (cond
+          ((and (not fs) glv) ;; if there is no faces, use glvertices for creating pqpmodel
+           (setq usefs (instance gl::glvertices :init nil))
+           (send usefs :transform (send ll :worldcoords))
+           (send usefs :append-glvertices glv)
+           (let ((m (send usefs (read-from-string
+                                 (format nil ":make-~Amodel"
+                                         (string-right-trim "-COLLISION-CHECK" (string collision-func))))
+                          :fat fat)))
+             (setf (get ll :pqpmodel) m)
+             ;; Also set pqpmodel to each collada-body for pqp-collision-distance with robot object
+             (dolist (bd collada-bodies)
+               (setf (get bd :pqpmodel) m)))
+           ;; collect glvertices for robot pqpmodel
+           (dolist (g glv) (push g all-glv)))
+          (fs
+           (setq usefs
+                 (append fs
+                         (mapcar #'(lambda (gv) (send gv :convert-to-faces :wrt :world)) glv)))
+           (send ll
+                 (read-from-string
+                  (format nil ":make-~Amodel"
+                          (string-right-trim "-COLLISION-CHECK" (string collision-func))))
+                 :fat fat
+                 :faces usefs)))))
+     ;; Create pqpmodel for the robot itself using all glvertices from all links
+     (when all-glv
+       (let ((robot-glv (instance gl::glvertices :init nil)))
+         (send robot-glv :transform (send self :worldcoords))
+         (send robot-glv :append-glvertices all-glv)
+         (let ((m (send robot-glv (read-from-string
+                                   (format nil ":make-~Amodel"
+                                           (string-right-trim "-COLLISION-CHECK" (string collision-func))))
                         :fat fat)))
-           (setf (get ll :pqpmodel) m)))
-        (fs
-         (setq usefs
-               (append fs
-                       (mapcar #'(lambda (gv) (send gv :convert-to-faces :wrt :world)) glv)))
-         (send ll
-               (read-from-string
-                (format nil ":make-~Amodel"
-                        (string-right-trim "-COLLISION-CHECK" (string collision-func))))
-               :fat fat
-               :faces usefs))))))
+           (setf (get self :pqpmodel) m))))))
   ;; Get all links, including those not explicitly listed in the :links attribute.
   ;; This is necessary because auto-generating from URDF can create links
   ;; that are not explicitly listed in the YAML configuration file.


### PR DESCRIPTION
When pqp-collision-distance was called with a robot object directly, it would use the default 10x10x10mm cube shape from collada-body instead of the actual mesh geometry. This happened because:

1. Robot object had no :pqpmodel set
2. pqp-collision-distance calls :make-pqpmodel when :pqpmodel is nil
3. :make-pqpmodel uses :faces which returns collada-body's default cube

This fix ensures pqpmodel is properly set for:
- Each collada-body (same as its parent link's pqpmodel)
- The robot object itself (combined glvertices from all links)

Now pqp-collision-distance works correctly whether called with the robot object or individual links.