### PR TITLE
Smooth out viewer wheel zoom with eased dolly

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -151,6 +151,20 @@ labelRenderer.domElement.style.cssText='position:absolute;inset:0;pointer-events
 const scene = new THREE.Scene(); scene.background = new THREE.Color(0x0f1115);
 const camera = new THREE.PerspectiveCamera(50,1,0.01,2000); camera.up.set(0,0,1);
 const controls = new OrbitControls(camera, renderer.domElement); controls.enableDamping=true;
+// Built-in dolly is applied instantly (damping only smooths rotate/pan), so the
+// wheel jumps the view in big steps. Drive zoom ourselves and ease toward a
+// target distance each frame for a smooth, glide-y zoom.
+controls.enableZoom=false;
+let zoomTarget=null;          // desired camera distance to target; null = follow actual
+const _zoomVec=new THREE.Vector3();
+renderer.domElement.addEventListener('wheel', ev=>{
+  if(!current) return;
+  ev.preventDefault();
+  const cur=camera.position.distanceTo(controls.target);
+  const base=(zoomTarget==null)?cur:zoomTarget;
+  const step=Math.max(-1,Math.min(1,ev.deltaY/100));   // normalize across mice/trackpads
+  zoomTarget=THREE.MathUtils.clamp(base*Math.pow(1.18,step), camera.near*2, camera.far*0.9);
+}, {passive:false});
 const tcontrols = new TransformControls(camera, renderer.domElement);
 tcontrols.addEventListener('dragging-changed', e=>{controls.enabled=!e.value;});
 scene.add(tcontrols);
@@ -161,7 +175,15 @@ const ground = new THREE.GridHelper(10,20,0x335577,0x223044); ground.rotation.x=
 $('#viewer').appendChild(labelRenderer.domElement);
 function resize(){const w=canvas.clientWidth,h=canvas.clientHeight;
   if(w&&h&&(canvas.width!==w||canvas.height!==h)){renderer.setSize(w,h,false);labelRenderer.setSize(w,h);camera.aspect=w/h;camera.updateProjectionMatrix();}}
-function animate(){resize();controls.update();renderer.render(scene,camera);labelRenderer.render(scene,camera);requestAnimationFrame(animate);}
+function animate(){resize();controls.update();
+  if(zoomTarget!=null){   // ease camera distance toward the wheel-set target
+    const cur=camera.position.distanceTo(controls.target);
+    const next=THREE.MathUtils.lerp(cur,zoomTarget,0.18);
+    _zoomVec.copy(camera.position).sub(controls.target).setLength(next).add(controls.target);
+    camera.position.copy(_zoomVec);
+    if(Math.abs(next-zoomTarget)<zoomTarget*1e-3) zoomTarget=null;   // settled
+  }
+  renderer.render(scene,camera);labelRenderer.render(scene,camera);requestAnimationFrame(animate);}
 animate();
 
 let current=null, modelName=null, currentEntry=null, frameMarkers=[], hoverTargets=[], showFrames=true, moveMode=false, rotMode=false, prefixMap={};
@@ -217,6 +239,7 @@ function frame(obj){
   controls.target.copy(c);
   camera.position.set(c.x+r*1.3,c.y-r*1.6,c.z+r*1.1);
   camera.near=r/100; camera.far=r*60; camera.updateProjectionMatrix();
+  zoomTarget=null;   // start following the freshly framed distance
   ground.position.set(c.x,c.y,box.min.z); ground.scale.setScalar(Math.max(1,r*2)/10*1.6);
 }
 function loadModel(e){


### PR DESCRIPTION
OrbitControls damping only smooths rotate/pan, so wheel zoom jumped the view in large steps. Take over zoom, normalize deltaY across mice and trackpads, and ease the camera distance toward a target each frame.