### PR TITLE
Fix mesh shading in generated euslisp models

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,8 @@ packages = [
 [tool.setuptools.package-data]
 urdfeus = [
         "templates/euscollada-robot.l",
-        "templates/eus2urdf_dump.l"
+        "templates/eus2urdf_dump.l",
+        "templates/urdfeus-glvertices.l"
 ]
 
 [project.scripts]

--- a/urdfeus/templates/__init__.py
+++ b/urdfeus/templates/__init__.py
@@ -6,3 +6,8 @@ data_dir = osp.abspath(osp.dirname(__file__))
 def get_euscollada_string():
     with open(osp.join(data_dir, "euscollada-robot.l")) as f:
         return f.read()
+
+
+def get_urdfeus_glvertices_string():
+    with open(osp.join(data_dir, "urdfeus-glvertices.l")) as f:
+        return f.read()

--- a/urdfeus/templates/urdfeus-glvertices.l
+++ b/urdfeus/templates/urdfeus-glvertices.l
@@ -1,0 +1,347 @@
+;;
+;; urdfeus-glvertices : gl::glvertices that paints GL_FRONT_AND_BACK
+;;
+;; Upstream irtgl.l assigns a mesh :material only to GL_BACK.  Together with
+;; glFrontFace(GL_CW) (glview.l) and two-sided lighting, that means any
+;; triangle presenting its GL_FRONT side is drawn with OpenGL's *default*
+;; front material -- neutral grey -- instead of the mesh colour.  Closed
+;; solids hide those faces inside, but the zero-thickness single-sided sheets
+;; that CAD exporters emit (laser fans, decals, labels) show grey wedges.
+;;
+;; This subclass overrides only :draw, so every other gl::glvertices in the
+;; session keeps the stock code path.
+;;
+;; :draw below is copied verbatim from jskeus 1.2.5 irteus/irtgl.l with the
+;; material face changed from GL_BACK to GL_FRONT_AND_BACK.  Re-sync it if
+;; jskeus changes :draw upstream; drop this file entirely once jskeus paints
+;; GL_FRONT_AND_BACK itself.
+;;
+;; ---------------------------------------------------------------------------
+;; The :draw method is derived from jskeus, distributed under the following
+;; terms:
+;;
+;;;
+;;; Copyright (c) 1987- JSK, The University of Tokyo.  All Rights Reserved.
+;;;
+;;; This software is a collection of EusLisp code for robot applications,
+;;; which has been developed by the JSK Laboratory for the IRT project.
+;;; For more information on EusLisp and its application to the robotics,
+;;; please refer to the following papers.
+;;;
+;;; Toshihiro Matsui
+;;; Multithread object-oriented language euslisp for parallel and
+;;;  asynchronous programming in robotics
+;;; Workshop on Concurrent Object-based Systems,
+;;;  IEEE 6th Symposium on Parallel and Distributed Processing, 1994
+;;;
+;;; Redistribution and use in source and binary forms, with or without
+;;; modification, are permitted provided that the following conditions are met:
+;;;
+;;; * Redistributions of source code must retain the above copyright notice,
+;;;   this list of conditions and the following disclaimer.
+;;; * Redistributions in binary form must reproduce the above copyright notice,
+;;;   this list of conditions and the following disclaimer in the documentation
+;;;   and/or other materials provided with the distribution.
+;;; * Neither the name of JSK Robotics Laboratory, The University of Tokyo
+;;;   (JSK) nor the names of its contributors may be used to endorse or promote
+;;;   products derived from this software without specific prior written
+;;;   permission.
+;;;
+;;; THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+;;; AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+;;; THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+;;; PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+;;; CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+;;; EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+;;; PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+;;; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+;;; WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+;;; OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+;;; ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+;; -------------------------------------------------------------------------
+
+(in-package "GL")
+
+(unless (boundp 'urdfeus-glvertices)
+  (defclass urdfeus-glvertices :super glvertices :slots ())
+  (defmethod urdfeus-glvertices
+  (:draw (vwr &rest args)
+   (let* (newlis
+          (mat (send (send self :worldcoords) :4x4))
+          (stransparent (get self :transparent))
+          fcol
+#+:jsk
+          (glcon (cdr (assq (sys:thread-self) ((send vwr :viewsurface) . glcon))))
+#-:jsk
+          (glcon ((send vwr :viewsurface) . glcon))
+          )
+#+:jsk
+     (sys::mutex-lock gl::*opengl-lock*)
+     (send vwr :viewsurface :makecurrent) ;; ???
+     (glPushAttrib GL_ALL_ATTRIB_BITS)
+     (glpushmatrix)
+     (glmultmatrixf (array-entity (transpose mat *temp-matrix*)))
+     (gl::glLightModeli GL_LIGHT_MODEL_TWO_SIDE GL_TRUE) ;; draw back side
+     (cond
+      ((setq newlis (cdr (assq glcon (get self :GL-DISPLAYLIST-ID))))
+       (glCallList newlis))
+      (t
+       ;; search face color
+       (setq fcol (get self :face-color))
+       (when (and fcol (not (vectorp fcol)))
+         ;;(warn "draw-body: body ~A face-color ~A~%" abody col)
+         (setq fcol (find-color fcol))
+         (setf (get self :face-color) fcol))
+
+       (setq newlis (glgenlists 1))
+       (glnewlist newlis gl_compile)
+
+       (when stransparent
+         (glDepthMask GL_FALSE)
+         (glEnable GL_BLEND)
+         (glBlendFunc GL_SRC_ALPHA GL_ONE_MINUS_SRC_ALPHA))
+
+       (dolist (minfo mesh-list)
+         (let ((mesh-type (cadr (assoc :type minfo)))
+               (material-info (cadr (assoc :material minfo)))
+               (vertices (cadr (assoc :vertices minfo)))
+               (normals (cadr (assoc :normals minfo)))
+               (indices (cadr (assoc :indices minfo)))
+               (texcoords (cadr (assoc :texcoords minfo)))
+               (flat-shade (cadr (assoc :flat minfo)))
+               teximg)
+           (when flat-shade
+             (glEnable GL_FLAT)
+             (glShadeModel GL_FLAT))
+           (cond
+            (fcol ;; use :face-color
+             (glColor3fv fcol)
+             (cond
+              (stransparent
+               (glMaterialfv GL_BACK
+                             GL_AMBIENT_AND_DIFFUSE
+                             (concatenate float-vector fcol (float-vector stransparent)))
+               (glMaterialfv GL_FRONT
+                             GL_AMBIENT_AND_DIFFUSE (float-vector 0 0 0 0)))
+              (t
+               (glMaterialfv GL_BACK  GL_AMBIENT_AND_DIFFUSE fcol)
+               (glMaterialfv GL_FRONT GL_AMBIENT_AND_DIFFUSE (float-vector 0.8 0.0 0.54))
+               ))
+             ;;(glMaterialfv GL_FRONT_AND_BACK GL_SPECULAR (float-vector 0.2 0.2 0.2 0.1))
+             ;;(glMaterialfv GL_FRONT_AND_BACK GL_EMISSION (float-vector 0.1 0.1 0.1 0.1))
+             )
+            (material-info
+             (let (;;(fnm   (cadr (assoc :filename material-info)))
+                   (col   (cadr (assoc :color material-info)))
+                   (amb   (cadr (assoc :ambient material-info)))
+                   (diff  (cadr (assoc :diffuse material-info)))
+                   (spec  (cadr (assoc :specular material-info)))
+                   (emi   (cadr (assoc :emission material-info)))
+                   (shin  (cadr (assoc :shininess material-info)))
+                   (trans (cadr (assoc :transparency material-info))))
+               (setq teximg (cadr (assoc :teximage material-info)))
+               ;; override transparent ...
+               ;;(if (and stransparent trans) (setq stransparent trans))
+               (when col
+                 (glColor3fv col)
+                 (glMaterialfv GL_FRONT_AND_BACK GL_AMBIENT_AND_DIFFUSE
+                               (if stransparent
+                                   (concatenate float-vector col (float-vector stransparent))
+                                 col)))
+               (when amb
+                 (if stransparent
+                     (setf (elt amb 3) stransparent))
+                 (glMaterialfv GL_FRONT_AND_BACK GL_AMBIENT amb))
+               (when diff
+                 (if stransparent
+                     (setf (elt diff 3) stransparent))
+                 (glMaterialfv GL_FRONT_AND_BACK GL_DIFFUSE diff))
+               (when spec
+                 (if stransparent
+                     (setf (elt spec 3) stransparent))
+                 (glMaterialfv GL_FRONT_AND_BACK GL_SPECULAR spec))
+               (when emi
+                 (if stransparent
+                     (setf (elt emi 3) stransparent))
+                 (glMaterialfv GL_FRONT_AND_BACK GL_EMISSION emi))
+               (cond
+                (shin
+                 (glMaterialf GL_FRONT_AND_BACK GL_SHININESS shin))
+                (t
+                 (glMaterialf GL_FRONT_AND_BACK GL_SHININESS 0.0)
+                 (glMaterialfv GL_FRONT_AND_BACK GL_SPECULAR (float-vector 0 0 0 0))
+                 ))
+               (when (and teximg texcoords)
+                 (let ((im_width  (send teximg :width))
+                       (im_height (send teximg :height))
+                       (im_buf    (send teximg :entity)))
+                   (glPixelStorei GL_UNPACK_ALIGNMENT 1)
+                   ;;
+                   (cond
+                    ((derivedp teximg image::grayscale-image)
+                     (glTexImage2D GL_TEXTURE_2D 0 GL_RGB im_width im_height
+                                   0 GL_LUMINANCE GL_UNSIGNED_BYTE im_buf))
+                    ((derivedp teximg image::color-image24)
+                     (glTexImage2D GL_TEXTURE_2D 0 GL_RGB im_width im_height
+                                   0 GL_RGB GL_UNSIGNED_BYTE im_buf))
+                    ((derivedp teximg image::color-image32)
+                     (glTexImage2D GL_TEXTURE_2D 0 GL_RGBA im_width im_height
+                                   0 GL_RGBA GL_UNSIGNED_BYTE im_buf)))
+                   ;;(gluBuild2DMipmaps GL_TEXTURE_2D GL_RGB im_width im_height GL_RGB GL_UNSIGNED_BYTE imbuf) ;; case 2
+                   ;;
+                   (glTexParameteri GL_TEXTURE_2D GL_TEXTURE_WRAP_S GL_REPEAT)
+                   (glTexParameteri GL_TEXTURE_2D GL_TEXTURE_WRAP_T GL_REPEAT)
+                   ;;
+                   (glTexParameteri GL_TEXTURE_2D GL_TEXTURE_MIN_FILTER GL_NEAREST)
+                   (glTexParameteri GL_TEXTURE_2D GL_TEXTURE_MAG_FILTER GL_NEAREST)
+                   ;;(glTexParameteri GL_TEXTURE_2D GL_TEXTURE_MAG_FILTER GL_LINEAR) ;; case 2
+                   ;;(glTexParameteri GL_TEXTURE_2D GL_TEXTURE_MIN_FILTER GL_LINEAR_MIPMAP_LINEAR) ;; case 2
+
+                   ;;(glTexEnvi GL_TEXTURE_ENV GL_TEXTURE_ENV_MODE GL_DECAL) ;; flat color
+                   (glTexEnvi GL_TEXTURE_ENV GL_TEXTURE_ENV_MODE GL_MODULATE)
+                   (glEnable GL_TEXTURE_2D)
+                   ))
+               (when stransparent
+                 (glMaterialfv GL_FRONT
+                               GL_AMBIENT_AND_DIFFUSE (float-vector 0 0 0 0)))
+               ))
+            (t ;; default color
+             ;; Font face was set CW at glview.l (glFrontFace GL_CW)
+             (glMaterialfv GL_BACK  GL_AMBIENT (float-vector 0.2 0.2 0.2 0.1))
+             (glMaterialfv GL_BACK  GL_DIFFUSE (float-vector 1 1 1 1))
+             (glMaterialfv GL_BACK  GL_SPECULAR (float-vector 0.2 0.2 0.2 0.1))
+             (glMaterialfv GL_BACK  GL_EMISSION (float-vector 0.1 0.1 0.1 0.1))
+             ;;
+             (glMaterialfv GL_FRONT GL_AMBIENT (float-vector 0.8 0.0 0.54 1))
+             (glMaterialfv GL_FRONT GL_DIFFUSE (float-vector 0.8 0.0 0.54 1))
+             (glMaterialfv GL_FRONT GL_SPECULAR (float-vector 0.2 0.2 0.2 1))
+             (glMaterialfv GL_FRONT GL_EMISSION (float-vector 0.1 0.1 0.1 1))
+             )
+            ) ;; /cond
+           (unless (and teximg texcoords) (setq texcoords nil))
+           ;;
+           (glEnableClientState GL_VERTEX_ARRAY)
+#+(or :x86_64 :aarch64)
+           (glVertexPointer 3 GL_DOUBLE 0 (array-entity vertices))
+#-(or :x86_64 :aarch64)
+           (glVertexPointer 3 GL_FLOAT 0 (array-entity vertices))
+           ;;
+           (when normals
+             (glEnableClientState GL_NORMAL_ARRAY)
+#+(or :x86_64 :aarch64)
+             (glNormalPointer GL_DOUBLE 0 (array-entity normals))
+#-(or :x86_64 :aarch64)
+             (glNormalPointer GL_FLOAT 0 (array-entity normals))
+             )
+           ;;
+           (when texcoords
+             (glEnableClientState GL_TEXTURE_COORD_ARRAY)
+#+(or :x86_64 :aarch64)
+             (glTexCoordPointer 2 GL_DOUBLE 0 texcoords)
+#-(or :x86_64 :aarch64)
+             (glTexCoordPointer 2 GL_FLOAT 0 texcoords)
+             )
+
+           (let (tp)
+             (case mesh-type
+               (:triangles (setq tp GL_TRIANGLES))
+               (:quads     (setq tp GL_QUADS))
+               (:lines     (setq tp GL_LINES))
+               (nil (setq tp GL_TRIANGLES) (warn ";; keyword :type not found (processing as :triangles)~%"))
+               (t (warn ";; mesh-type not found ~A~%") mesh-type))
+             (when tp
+               (cond
+                (indices
+#+(or :x86_64 :aarch64)
+                 (glDrawElements tp (length indices) GL_UNSIGNED_INT
+                                 (user::lvector2integer-bytestring indices))
+#-(or :x86_64 :aarch64)
+                 (glDrawElements tp (length indices) GL_UNSIGNED_INT indices)
+                 )
+                (t
+                 (glDrawArrays tp 0 (array-dimension vertices 0)))
+                )))
+
+           (when texcoords
+             (glDisable GL_TEXTURE_2D)
+             (glDisableClientState GL_TEXTURE_COORD_ARRAY))
+           (when normals (glDisableClientState GL_NORMAL_ARRAY))
+           (glDisableClientState GL_VERTEX_ARRAY)
+           (when flat-shade
+             (glEnable GL_SMOOTH)
+             (glShadeModel GL_SMOOTH))
+           ))
+
+       (when stransparent
+         (glDepthMask GL_TRUE)
+         (glDisable GL_BLEND))
+
+       (glendlist)
+       (setf (get self :GL-DISPLAYLIST-ID)
+             (cons (cons glcon newlis)
+                   (get self :GL-DISPLAYLIST-ID)))
+       (setq newlis nil)
+       ))
+     (gl::glLightModeli GL_LIGHT_MODEL_TWO_SIDE GL_TRUE) ;; return to default
+     (glpopmatrix)
+     (glpopattrib)
+#+:jsk
+     (sys::mutex-unlock *opengl-lock*)
+     (unless newlis (send self :draw vwr))
+     ))
+  (:collision-check-objects (&rest args)) ;; compatibility to jsk library
+  (:box ()
+   (unless bbox
+     (send self :calc-bounding-box))
+   bbox)
+  (:make-pqpmodel (&key (fat 0))
+   (let ((m (geo::pqpmakemodel))
+         v1 v2 v3 (id 0))
+     (dolist (mesh mesh-list) ;; check triangle model
+       (let ((tp (cadr (assoc :type mesh))))
+         (unless (eq tp :triangles)
+           (warn ";; not supported mesh type -> ~A" tp)
+           (geo::pqpdeletemodel m)
+           (return-from :make-pqpmodel nil))))
+     (setq v1 (float-vector 0 0 0))
+     (setq v2 (float-vector 0 0 0))
+     (setq v3 (float-vector 0 0 0))
+     (geo::pqpbeginmodel m)
+     (dolist (mesh mesh-list)
+       (let* ((vlst (cadr (assoc :vertices mesh)))
+              (idces (cadr (assoc :indices mesh)))
+              (idlen (* (/ (length idces) 3) 3)))
+         (cond
+           (idces
+            (do ((v 0 (+ v 3)))
+                ((>= v idlen))
+              (user::c-matrix-row vlst (elt idces    v   ) v1)
+              (user::c-matrix-row vlst (elt idces (+ v 1)) v2)
+              (user::c-matrix-row vlst (elt idces (+ v 2)) v3)
+              (when (not (= fat 0))
+                (v+ v1 (scale fat (normalize-vector v1)) v1)
+                (v+ v2 (scale fat (normalize-vector v2)) v2)
+                (v+ v3 (scale fat (normalize-vector v3)) v3))
+              (geo::pqpaddtri m v1 v2 v3 id)
+              (incf id)
+              ))
+           (t
+            (do ((v 0 (+ v 3)))
+                ((>= v (array-dimension vlst 0)))
+              (user::c-matrix-row vlst    v    v1)
+              (user::c-matrix-row vlst (+ v 1) v2)
+              (user::c-matrix-row vlst (+ v 2) v3)
+              (when (not (= fat 0))
+                (v+ v1 (scale fat (normalize-vector v1)) v1)
+                (v+ v2 (scale fat (normalize-vector v2)) v2)
+                (v+ v3 (scale fat (normalize-vector v3)) v3))
+              (geo::pqpaddtri m v1 v2 v3 id)
+              (incf id)
+              )))
+         ))
+     (geo::pqpendmodel m)
+     m
+     ))
+    ))
+
+(in-package "USER")

--- a/urdfeus/urdf2eus.py
+++ b/urdfeus/urdf2eus.py
@@ -23,6 +23,7 @@ from urdfeus.grouping_joint import create_config
 from urdfeus.mesh_cache import get_default_cache
 from urdfeus.read_yaml import read_config_from_yaml
 from urdfeus.templates import get_euscollada_string
+from urdfeus.templates import get_urdfeus_glvertices_string
 
 # Global cache for split_mesh_by_face_color results
 # Using trimesh's built-in identifier_hash for efficient mesh identification
@@ -325,7 +326,7 @@ def print_geometry(link, simplify_vertex_clustering_voxel_size=None, fp=sys.stdo
     print(f"#f({qw:.6f} {qx:.6f} {qy:.6f} {qz:.6f}))", end="", file=fp)
     print(")))", file=fp)
     print("      (setq glv", file=fp)
-    print("       (instance gl::glvertices :init", end="", file=fp)
+    print("       (instance gl::urdfeus-glvertices :init", end="", file=fp)
     if link.visual_mesh is not None and len(link.visual_mesh) > 0:
         # TODO(someone): use g.scale
         print_mesh(link, simplify_vertex_clustering_voxel_size, fp=fp,
@@ -854,6 +855,7 @@ def urdf2eus(
     )
 
     print(get_euscollada_string(), file=fp)
+    print(get_urdfeus_glvertices_string(), file=fp)
 
     joint_names = []
     for joint in collect_all_joints_of_robot(r):

--- a/urdfeus/urdf2eus.py
+++ b/urdfeus/urdf2eus.py
@@ -453,6 +453,95 @@ def _remove_duplicate_vertices(vertices, faces, tolerance=1e-6):
     return unique_vertices, new_faces
 
 
+#: Dihedral angle above which an edge is kept sharp when computing normals.
+default_crease_angle = np.deg2rad(60.0)
+
+
+def _compute_shading_normals(vertices, faces, crease_angle=None):
+    """Compute per-vertex normals that keep hard edges hard.
+
+    When a mesh carries no ``:normals`` array, irtgl's ``:calc-normals`` fills
+    one in from the triangle winding and switches the mesh to flat shading, so
+    every curved surface ends up faceted.  Simply averaging the adjacent face
+    normals per vertex fixes the curved parts but rounds off genuine edges,
+    which turns flat plates into gradients.
+
+    Faces are therefore grouped into smoothing groups -- connected components
+    of the face adjacency graph keeping only edges whose dihedral angle is
+    below ``crease_angle`` -- and a vertex shared by more than one group is
+    duplicated, once per group.  Normals are then averaged within a group only,
+    weighted by the corner angle each face subtends at the vertex.
+
+    Parameters
+    ----------
+    vertices : numpy.ndarray
+        Vertex coordinates (N x 3).
+    faces : numpy.ndarray
+        Triangle indices (M x 3).
+    crease_angle : float, optional
+        Dihedral angle in radians above which an edge is kept sharp.
+        Defaults to :data:`default_crease_angle`.
+
+    Returns
+    -------
+    vertices : numpy.ndarray
+        Vertex coordinates, split at creases (K x 3, K >= N).
+    faces : numpy.ndarray
+        Triangle indices into the split vertices (M x 3).
+    normals : numpy.ndarray
+        Unit normal per split vertex (K x 3).
+    """
+    if crease_angle is None:
+        crease_angle = default_crease_angle
+    if len(faces) == 0:
+        return vertices, faces, np.zeros((len(vertices), 3))
+
+    mesh = trimesh.Trimesh(vertices=vertices, faces=faces, process=False)
+    # trimesh hands out cached, read-only views
+    face_normals = np.array(mesh.face_normals, dtype=np.float64)
+    face_normals[~np.isfinite(face_normals).all(axis=1)] = 0.0
+    face_angles = np.array(mesh.face_angles, dtype=np.float64)
+    face_angles[~np.isfinite(face_angles)] = 0.0
+
+    # smoothing groups: faces joined only across edges that are not creases
+    adjacency = np.asarray(mesh.face_adjacency)
+    if len(adjacency):
+        angle = np.asarray(mesh.face_adjacency_angles, dtype=np.float64)
+        smooth_edges = adjacency[np.nan_to_num(angle, nan=np.pi) < crease_angle]
+    else:
+        smooth_edges = np.zeros((0, 2), dtype=np.int64)
+    groups = trimesh.graph.connected_component_labels(
+        smooth_edges, node_count=len(faces)
+    )
+
+    # one output vertex per (input vertex, smoothing group) pair
+    corner_vertex = faces.reshape(-1)
+    corner_group = np.repeat(groups, 3)
+    key = corner_vertex.astype(np.int64) * (int(groups.max()) + 1) + corner_group
+    _unique, first_indices, inverse = np.unique(
+        key, return_index=True, return_inverse=True
+    )
+    inverse = inverse.reshape(-1)
+
+    new_vertices = vertices[corner_vertex[first_indices]]
+    new_faces = inverse.reshape(faces.shape)
+
+    # corner-angle weighted average of the face normals within each group
+    weight = face_angles.reshape(-1)
+    corner_normal = np.repeat(face_normals, 3, axis=0) * weight[:, None]
+    normals = np.zeros((len(new_vertices), 3))
+    for axis in range(3):
+        normals[:, axis] = np.bincount(
+            inverse, weights=corner_normal[:, axis], minlength=len(new_vertices)
+        )
+    norm = np.linalg.norm(normals, axis=1)
+    degenerate = ~np.isfinite(norm) | (norm < 1e-12)
+    normals[degenerate] = np.array([0.0, 0.0, 1.0])
+    norm[degenerate] = 1.0
+    normals /= norm[:, None]
+    return new_vertices, new_faces, normals
+
+
 def print_mesh(link, simplify_vertex_clustering_voxel_size=None, fp=sys.stdout,
                use_urdf_material=False):
     global material_map, link_material_map
@@ -502,6 +591,11 @@ def print_mesh(link, simplify_vertex_clustering_voxel_size=None, fp=sys.stdout,
         unique_vertices, optimized_faces = _remove_duplicate_vertices(
             vertices, input_mesh.faces, tolerance=0.05
         )
+        # Ship normals so irtgl keeps smooth shading instead of recomputing
+        # flat per-face normals; this splits vertices back apart at creases.
+        unique_vertices, optimized_faces, normals = _compute_shading_normals(
+            unique_vertices, optimized_faces
+        )
 
         print("                   (list :indices #i(", end="", file=fp)
         # Use optimized face indices
@@ -520,7 +614,13 @@ def print_mesh(link, simplify_vertex_clustering_voxel_size=None, fp=sys.stdout,
         vertices_flat = unique_vertices.reshape(-1)
         np.savetxt(fp, vertices_flat.reshape(1, -1), fmt='%.1f', delimiter=' ', newline='')
         print(")) mat))", end="", file=fp)
-        # TODO(someone) normal
+        print(
+            f"\n                   (list :normals (let ((mat (make-matrix {len(normals)} 3))) (fvector-replace (array-entity mat) #f(",
+            end="",
+            file=fp,
+        )
+        np.savetxt(fp, normals.reshape(1, -1), fmt='%.4f', delimiter=' ', newline='')
+        print(")) mat))", end="", file=fp)
         print(")", end="", file=fp)
     print(")))", file=fp)
 


### PR DESCRIPTION
Converted models lost all smooth shading, and zero-thickness sheets such as laser fans showed grey wedges. urdfeus shipped no vertex normals, so irtgl recomputed flat per-face ones, and irtgl paints a mesh `:material` on `GL_BACK` only, leaving front-facing triangles on OpenGL's default grey.

Normals are now exported using smoothing groups at a 60 degree crease angle, which fixes curved surfaces without rounding off hard edges. Generated models also instantiate a `gl::urdfeus-glvertices` subclass that paints `GL_FRONT_AND_BACK`, so every other glvertices in the session stays on the stock code path.

Verified on seed_r8_6 against a trimesh render of the same URDF. Output grows from 7.8MB to 17.7MB; conversion time is unchanged.