### PR TITLE
Read the PR labels from the API in auto-merge

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -69,15 +69,36 @@ jobs:
 
   auto-merge:
     needs: [formatting, tests-3x]
-    if: contains(github.event.pull_request.labels.*.name, 'auto-merge-ok')
+    # Ask the API for the labels rather than reading them off
+    # github.event.pull_request: that payload is a snapshot taken when the PR
+    # was opened, and the bump workflow attaches its labels a moment later, so
+    # a job gated on the payload skips whenever it loses that race.
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
+    outputs:
+      auto-merge-ok: ${{ steps.labels.outputs.auto-merge-ok }}
+      release: ${{ steps.labels.outputs.release }}
 
     steps:
+      - name: Read the labels currently on the PR
+        id: labels
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          names=$(gh pr view "${{ github.event.pull_request.number }}" \
+            --repo "${{ github.repository }}" --json labels --jq '[.labels[].name]')
+          echo "labels: $names"
+          for label in auto-merge-ok release; do
+            has=$(jq -r --arg l "$label" 'index($l) != null' <<< "$names")
+            echo "$label=$has" >> "$GITHUB_OUTPUT"
+          done
+
       - name: Checkout repository
+        if: steps.labels.outputs.auto-merge-ok == 'true'
         uses: actions/checkout@v4
 
       - name: Auto merge PR with auto-merge-ok label
-        if: success()
+        if: steps.labels.outputs.auto-merge-ok == 'true'
         uses: pascalgn/automerge-action@v0.16.3
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
@@ -88,7 +109,7 @@ jobs:
   tag-release:
     runs-on: ubuntu-latest
     needs: auto-merge
-    if: contains(github.event.pull_request.labels.*.name, 'release')
+    if: needs.auto-merge.outputs.release == 'true'
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
The `auto-merge` and `tag-release` jobs were gated on `github.event.pull_request.labels`, which is a snapshot taken when the pull request was opened. The bump workflow attaches `auto-merge-ok` and `release` about a second later, so the gate depends on winning that race. It won on all fourteen previous bump PRs and lost on #65, leaving 1.2.0 unreleased with every check green.

The job now asks the API for the labels at run time and passes the result down to `tag-release`, so the outcome no longer depends on webhook timing. The job-level `if` is kept as `github.event_name == 'pull_request'` only, since the workflow also runs on push and schedule where there is no PR to query.

Note that #65 cannot pick this up on its own: a `pull_request` run uses the workflow file from the PR's own branch. After this merges, either update that branch from main or redo the bump.