### PR TITLE
Test the interpreters where the optional extra breaks

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,6 +30,9 @@ jobs:
     name: Run Unit Tests
     runs-on: ${{ matrix.os }}
     strategy:
+      # One failing interpreter should not cancel the others: knowing whether a
+      # break is version-specific is most of the diagnosis.
+      fail-fast: false
       # 3.12 is the newest interpreter open3d ships a wheel for, and 3.13 is
       # the first one it does not; running both is what keeps the optional
       # extra honest as interpreters move on.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,8 +30,11 @@ jobs:
     name: Run Unit Tests
     runs-on: ${{ matrix.os }}
     strategy:
+      # 3.12 is the newest interpreter open3d ships a wheel for, and 3.13 is
+      # the first one it does not; running both is what keeps the optional
+      # extra honest as interpreters move on.
       matrix:
-        python-version: [3.10.13, 3.11.7]
+        python-version: ['3.10', '3.11', '3.12', '3.13']
         os: [ubuntu-22.04]
     steps:
     - uses: actions/checkout@v4
@@ -105,6 +108,47 @@ jobs:
           MERGE_LABELS: "auto-merge-ok"
           MERGE_METHOD: squash
           MERGE_DELETE_BRANCH: true
+
+  released-resolution:
+    name: Resolve the published package
+    # A wider unit-test matrix cannot catch this. CI installs the checkout, so
+    # the resolver can never walk urdfeus itself backwards; installing the
+    # published package by name can, and did -- `urdfeus[all]` quietly resolved
+    # to 0.0.4 on 3.13 because open3d ships no wheel there, warning instead of
+    # failing. Only run where a red build is actionable, not on every PR.
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-22.04
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ['3.10', '3.12', '3.13']
+    steps:
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install the published package by name
+        run: pip install --no-cache-dir "urdfeus[all]"
+
+      - name: Fail if the resolver did not pick the newest release
+        run: |
+          python - <<'CHECK'
+          import json
+          import urllib.request
+          from importlib.metadata import version
+
+          with urllib.request.urlopen(
+                  "https://pypi.org/pypi/urdfeus/json") as response:
+              latest = json.load(response)["info"]["version"]
+          installed = version("urdfeus")
+          print(f"installed {installed}, latest on PyPI {latest}")
+          if installed != latest:
+              raise SystemExit(
+                  f"urdfeus[all] resolved to {installed}, not {latest}: an"
+                  " optional dependency is unsatisfiable on this interpreter"
+                  " and the resolver fell back to an older release")
+          CHECK
 
   tag-release:
     runs-on: ubuntu-latest

--- a/tests/urdfeus_tests/test_console_scripts.py
+++ b/tests/urdfeus_tests/test_console_scripts.py
@@ -18,6 +18,15 @@ def run_command(cmd):
     return result
 
 
+def is_open3d_available():
+    """Mesh simplification goes through open3d, which has no wheel past cp312."""
+    try:
+        import open3d  # noqa: F401
+    except ImportError:
+        return False
+    return True
+
+
 def is_euslisp_available():
     """Check if roseus/euslisp is available."""
     result = run_command("which roseus")
@@ -38,20 +47,30 @@ class TestConsoleScripts(unittest.TestCase):
         target_mesh = osp.join(osp.dirname(self.urdfpath), "meshes", "base_link.dae")
         output_eus_path = osp.join(osp.dirname(self.urdfpath), "meshes", "base_link.l")
 
-        cmds = [
-            f"mesh2eus {target_mesh} {output_eus_path}",
-            f"mesh2eus {target_mesh} {output_eus_path} --voxel-size 0.001",
-        ]
-        for cmd in cmds:
-            result = run_command(cmd)
-            assert result.returncode == 0
+        result = run_command(f"mesh2eus {target_mesh} {output_eus_path}")
+        assert result.returncode == 0
+
+    @unittest.skipUnless(is_open3d_available(), "open3d not available")
+    def test_mesh2eus_with_voxel_size(self):
+        target_mesh = osp.join(osp.dirname(self.urdfpath), "meshes", "base_link.dae")
+        output_eus_path = osp.join(osp.dirname(self.urdfpath), "meshes", "base_link.l")
+
+        result = run_command(
+            f"mesh2eus {target_mesh} {output_eus_path} --voxel-size 0.001")
+        assert result.returncode == 0
 
     def test_urdf2eus(self):
+        output_eus_path = osp.join(osp.dirname(self.urdfpath), "fetch.l")
+
+        result = run_command(f"urdf2eus {self.urdfpath} {output_eus_path}")
+        assert result.returncode == 0
+
+    @unittest.skipUnless(is_open3d_available(), "open3d not available")
+    def test_urdf2eus_with_voxel_size(self):
         output_eus_path = osp.join(osp.dirname(self.urdfpath), "fetch.l")
         yaml_path = osp.join(data_dir, "fetch.yaml")
 
         cmds = [
-            f"urdf2eus {self.urdfpath} {output_eus_path}",
             f"urdf2eus {self.urdfpath} {output_eus_path} --voxel-size 0.001",
             f"urdf2eus {self.urdfpath} {output_eus_path}"
             + f" --voxel-size 0.001 --yaml-path {yaml_path}",
@@ -70,8 +89,11 @@ class TestConsoleScripts(unittest.TestCase):
         valid_name_cmds = [
             f"urdf2eus {self.urdfpath} {output_eus_path} --name my_robot",
             f"urdf2eus {self.urdfpath} {output_eus_path} --name robot-v1 --yaml-path {yaml_path}",
-            f"urdf2eus {self.urdfpath} {output_eus_path} --name _test_robot --voxel-size 0.001",
         ]
+        if is_open3d_available():
+            valid_name_cmds.append(
+                f"urdf2eus {self.urdfpath} {output_eus_path}"
+                + " --name _test_robot --voxel-size 0.001")
 
         for cmd in valid_name_cmds:
             with self.subTest(cmd=cmd):

--- a/tests/urdfeus_tests/test_urdfeus.py
+++ b/tests/urdfeus_tests/test_urdfeus.py
@@ -9,6 +9,15 @@ from urdfeus.urdf2eus import urdf2eus
 data_dir = osp.abspath(osp.dirname(__file__))
 
 
+def is_open3d_available():
+    """Mesh simplification goes through open3d, which has no wheel past cp312."""
+    try:
+        import open3d  # noqa: F401
+    except ImportError:
+        return False
+    return True
+
+
 class TestURDF2EUS(unittest.TestCase):
     def test_urdf2eus(self):
         urdf2eus(fetch_urdfpath())
@@ -16,4 +25,6 @@ class TestURDF2EUS(unittest.TestCase):
         urdf2eus(pr2_urdfpath())
         urdf2eus(pr2_urdfpath(), osp.join(data_dir, "pr2.yaml"))
 
+    @unittest.skipUnless(is_open3d_available(), "open3d not available")
+    def test_urdf2eus_with_vertex_clustering(self):
         urdf2eus(pr2_urdfpath(), simplify_vertex_clustering_voxel_size=0.001)


### PR DESCRIPTION
The unit-test matrix stopped at 3.11, one version short of where the interesting behaviour is: 3.12 is the newest interpreter open3d ships a wheel for, and 3.13 is the first it does not. It now runs 3.10 through 3.13, and the mesh-simplification tests skip when open3d is absent instead of failing on the import.

A wider matrix alone would not have caught `urdfeus[all]` silently resolving to 0.0.4 — CI installs the checkout, so the resolver can never walk urdfeus itself backwards. Only installing the published package by name can, so this adds a scheduled job that does that on 3.10/3.12/3.13 and fails when it lands on anything but the newest release. It is gated to schedule and manual runs, since a red build there is about the published artifact rather than the pull request.

Note that job will be red until a release carrying #69 goes out: 1.2.0 as published really does resolve to 0.0.4 on 3.13. That is the check working.