### PR TITLE
Allow dumping an object from a live irteusgl session

### DIFF
--- a/urdfeus/eus2urdf.py
+++ b/urdfeus/eus2urdf.py
@@ -36,6 +36,17 @@ _DUMP_SCRIPT = osp.join(osp.dirname(__file__), "templates", "eus2urdf_dump.l")
 _INF_LIMIT = 1e30
 
 
+def dump_script_path():
+    """Return the path of the irteusgl dump script shipped with urdfeus.
+
+    A live irteusgl session can ``(load ...)`` it to get ``dump-object-json``,
+    which writes the same JSON dump :func:`eus2urdf_from_data` consumes. The
+    script only runs its own file+constructor conversion when
+    ``*eus2urdf-model-path*`` is set, so loading it is side-effect free.
+    """
+    return _DUMP_SCRIPT
+
+
 def _default_constructor_name(eus_path):
     """Return the conventional constructor name for an EusLisp model file.
 
@@ -348,6 +359,55 @@ def eus2urdf(
     str
         Path to the written ``.urdf`` file.
     """
+    data = dump_eus_model(eus_path, constructor=constructor, irteusgl=irteusgl)
+    return eus2urdf_from_data(
+        data,
+        output_dir,
+        package_name=package_name,
+        robot_name=robot_name,
+        mesh_format=mesh_format,
+        draco=draco,
+    )
+
+
+def eus2urdf_from_data(
+    data,
+    output_dir,
+    package_name=None,
+    robot_name=None,
+    mesh_format="glb",
+    draco=False,
+):
+    """Write a URDF ROS package from an already-dumped EusLisp model.
+
+    This is the half of :func:`eus2urdf` that does not need ``irteusgl``: it
+    takes the JSON dump described by ``templates/eus2urdf_dump.l`` and turns it
+    into ``package.xml`` + ``urdf/`` + ``meshes/``. Callers that obtain the dump
+    some other way -- most notably ``dump-object-json`` called from inside a
+    live irteusgl session, which can convert objects built at runtime such as
+    ``(make-cube 100 200 300)`` -- go through this entry point instead.
+
+    Parameters
+    ----------
+    data : dict
+        Parsed JSON dump (see ``templates/eus2urdf_dump.l`` for the schema).
+    output_dir : str
+        Directory of the ROS package to create.
+    package_name : str or None
+        ROS package name used in ``package://`` mesh paths. Defaults to the
+        output directory's base name.
+    robot_name : str or None
+        ``<robot name>`` and urdf file stem. Defaults to ``data['robot_name']``.
+    mesh_format : str
+        Mesh file extension understood by ``trimesh.export`` (default ``glb``).
+    draco : bool
+        Compress glb meshes with Draco. See :func:`eus2urdf`.
+
+    Returns
+    -------
+    str
+        Path to the written ``.urdf`` file.
+    """
     export_draco = None
     if draco:
         mesh_format = "glb"
@@ -358,8 +418,6 @@ def eus2urdf(
                 "draco=True requires the DracoPy package "
                 + "(pip install dracopy).")
         export_draco = export_glb_with_draco
-
-    data = dump_eus_model(eus_path, constructor=constructor, irteusgl=irteusgl)
 
     output_dir = osp.abspath(output_dir)
     if package_name is None:
@@ -478,6 +536,43 @@ def eus2urdf(
         with open(osp.join(output_dir, "objects.json"), "w") as f:
             json.dump(data["scene_objects"], f)
     return urdf_path
+
+
+def movable_joint_spec(data):
+    """Describe the movable joints of a dump in the order EusLisp reports them.
+
+    The i-th entry corresponds to the i-th joint of
+    ``(eus2urdf-movable-joints obj)``, which is how a caller that logged joint
+    angles from a live session lines them up with the URDF this dump produces.
+    Matching by index rather than by name is deliberate: eus joint names are
+    not unique across a model, so urdfeus renames some of them.
+
+    Parameters
+    ----------
+    data : dict
+        Parsed JSON dump.
+
+    Returns
+    -------
+    list[tuple[str, float]]
+        ``(urdf_joint_name, unit_scale)`` pairs. Multiplying the EusLisp joint
+        value (degrees for rotational joints, millimetres for linear ones) by
+        ``unit_scale`` gives the URDF value (radians, metres).
+    """
+    joint_unames, _ = _unique_name_map(data["joints"])
+    follower = set()
+    for joint in data["joints"]:
+        for f in (joint["mimic"] or []):
+            follower.add(f["joint"])
+    spec = []
+    for i, joint in enumerate(data["joints"]):
+        if not joint["movable"]:
+            continue
+        jtype = _classify_joint(joint, joint["name"] in follower)
+        scale = (1.0 / meter2millimeter) if jtype == "prismatic" \
+            else float(np.pi / 180.0)
+        spec.append((joint_unames[i], scale))
+    return spec
 
 
 def frames_relative(data, link_names=None):

--- a/urdfeus/templates/eus2urdf_dump.l
+++ b/urdfeus/templates/eus2urdf_dump.l
@@ -9,9 +9,17 @@
 ;;   *eus2urdf-model-path*   : path to the .l model file to (load)
 ;;   *eus2urdf-constructor*  : symbol/string naming the constructor function
 ;;   *eus2urdf-out-path*     : path to write the JSON dump to
+;;
+;; Leaving *eus2urdf-model-path* unset makes loading this file side-effect
+;; free, which is how a live irteusgl session picks up (dump-object-json obj
+;; path): the same dump, but of an object that already exists in the session
+;; -- including one built at runtime, e.g. (make-cube 100 200 300).
 
 (defvar *out*)
 (defvar *movable-joints* nil)
+(defvar *eus2urdf-model-path* nil)
+(defvar *eus2urdf-constructor* nil)
+(defvar *eus2urdf-out-path* nil)
 
 (defun pj-str (s)
   ;; print a JSON string (with minimal escaping) to *out*
@@ -424,12 +432,128 @@
     (format *out* "}")
     (close *out*)))
 
+(defun body-meshes-of (obj)
+  ;; "meshes" array for an object that is a body/bodyset rather than a link
+  ;; tree. Mirrors the mesh half of dump-link.
+  (let ((bs (if (find-method obj :bodies) (send obj :bodies) (list obj))))
+    (format *out* "[")
+    (let ((first t))
+      (dolist (b bs)
+        (cond
+          ((and (find-method b :glvertices) (send b :glvertices))
+           (unless first (format *out* ","))
+           (setq first nil)
+           (dump-mesh (send b :glvertices)))
+          ((and (find-method b :faces) (send b :faces))
+           (unless first (format *out* ","))
+           (setq first nil)
+           (dump-plain-body b)))))
+    (format *out* "]")))
+
+(defun dump-single-body (b)
+  ;; A standalone body has no link tree (make-cube, make-cylinder, a mesh
+  ;; loaded with load-mesh-file, ...). Emit it as a one-link model so it goes
+  ;; through exactly the same URDF path as a robot.
+  (let ((name (or (and (find-method b :name) (send b :name)) "body")))
+    (setq *movable-joints* nil)
+    (send b :worldcoords)
+    (setq *out* (open *eus2urdf-out-path* :direction :output))
+    (format *out* "{")
+    (format *out* "\"robot_name\":") (pj-str name)
+    (format *out* ",\"root_link\":") (pj-str name)
+    (format *out* ",\"links\":[{\"name\":") (pj-str name)
+    (format *out* ",\"parent\":null,\"joint\":null")
+    (format *out* ",\"pos\":") (pj-fvec (send b :worldpos))
+    (format *out* ",\"rot\":") (pj-mat (send b :worldrot))
+    (format *out* ",\"weight\":0,\"centroid\":null,\"inertia\":null")
+    (format *out* ",\"meshes\":") (body-meshes-of b)
+    (format *out* "}]")
+    (format *out* ",\"joints\":[],\"frames\":[]}")
+    (close *out*)))
+
+(defun eus2urdf-joint-list-of (o)
+  ;; joint-list of o, or nil for objects that have no joints
+  (if (find-method o :joint-list) (send o :joint-list) nil))
+
+(defun eus2urdf-save-angles (o)
+  ;; [(joint . angle) ...] for o and, for a scene-model, its member objects
+  (let ((saved nil))
+    (dolist (j (eus2urdf-joint-list-of o))
+      (push (cons j (send j :joint-angle)) saved))
+    (when (find-method o :objects)
+      (dolist (c (send o :objects))
+        (dolist (j (eus2urdf-joint-list-of c))
+          (push (cons j (send j :joint-angle)) saved))))
+    (nreverse saved)))
+
+(defun eus2urdf-restore-angles (saved)
+  (dolist (p saved) (send (car p) :joint-angle (cdr p))))
+
+(defun eus2urdf-movable-joints (obj)
+  "Movable joints of OBJ in the order dump-object-json emits them.
+
+   This is the ordering contract between a dump and anything that records
+   OBJ's joint angles over time: the i-th joint here is the i-th movable
+   entry of the dumped \"joints\" array, and so the i-th movable joint of the
+   URDF. Matching by index rather than by name matters because eus joint
+   names are not unique -- a hand reusing :j10/:j11 on every finger is
+   normal, and urdfeus renames such joints when it writes the URDF."
+  (cond
+    ((find-method obj :objects)
+     (apply #'append
+            (mapcar #'(lambda (o)
+                        (if (scene-physical-p o)
+                            (eus2urdf-movable-joints o)
+                            nil))
+                    (send obj :objects))))
+    ((and (find-method obj :links) (send obj :links))
+     (let ((jl (send obj :joint-list)))
+       (remove-if-not
+        #'(lambda (j) (memq j jl))
+        (remove nil (mapcar #'(lambda (l) (send l :joint))
+                            (collect-all-links (object-root obj)))))))
+    (t nil)))
+
+(defun eus2urdf-root-link (obj)
+  "Link whose frame the URDF written for OBJ is expressed in.
+
+   A dump bakes no world pose into the URDF, so this is the link a recorder
+   must query to place the model: its worldcoords is the model's root pose."
+  (cond
+    ((find-method obj :objects) nil)  ;; scene: root is the synthetic world
+    ((and (find-method obj :links) (send obj :links)) (object-root obj))
+    (t obj)))
+
+(defun dump-object-json (obj path)
+  "Dump OBJ to PATH as eus2urdf JSON, then restore OBJ's joint angles.
+
+   OBJ may be a robot/cascaded-link, a scene-model, or a plain body such as
+   the result of (make-cube 100 200 300). Dumping zeroes every movable joint
+   (that is what makes the link transforms usable as URDF joint origins), so
+   the previous angles are put back before returning -- this is safe to call
+   from inside a running motion."
+  (let ((prev-out *eus2urdf-out-path*)
+        (saved (eus2urdf-save-angles obj)))
+    (setq *eus2urdf-out-path* path)
+    (unwind-protect
+        (cond
+          ((find-method obj :objects) (dump-scene obj))
+          ((and (find-method obj :links) (send obj :links)) (dump-robot obj))
+          (t (dump-single-body obj)))
+      (eus2urdf-restore-angles saved)
+      (send obj :worldcoords)
+      (setq *eus2urdf-out-path* prev-out)))
+  path)
+
 (defun eus2urdf-dump ()
   (let ((r (eus2urdf-instantiate)))
     (if (find-method r :objects)
         (dump-scene r)
         (dump-robot r))))
 
-(load *eus2urdf-model-path*)
-(eus2urdf-dump)
-(exit)
+;; Only run the file+constructor conversion when a model path was supplied.
+;; Without it this file is a library: (load) it and call dump-object-json.
+(when *eus2urdf-model-path*
+  (load *eus2urdf-model-path*)
+  (eus2urdf-dump)
+  (exit))


### PR DESCRIPTION
eus2urdf could only convert a model it instantiated itself, from a file and a constructor name, which leaves out anything built at runtime -- an object assembled in a session, or a plain `(make-cube 100 200 300)`.

Guard the dump script's file+constructor path on `*eus2urdf-model-path*` so the file is loadable as a library, and add `dump-object-json` to it, dispatching over robots, scene-models and standalone bodies and restoring joint angles afterwards.

On the Python side, split the half that needs no irteusgl out as `eus2urdf_from_data`, and add `movable_joint_spec`, which pairs each movable joint with its URDF name and unit scale by index -- eus joint names are not unique across a model, and urdfeus renames some of them.