### PR TITLE
Handle multi-DOF joints instead of dying on them

### DIFF
--- a/urdfeus/eus2urdf.py
+++ b/urdfeus/eus2urdf.py
@@ -348,6 +348,17 @@ def _classify_joint(joint, is_follower):
     linear = "linear" in jtype
     is_master = bool(joint["mimic"])
     min_v, max_v = joint["min"], joint["max"]
+
+    # A multi-DOF joint (6dof, sphere) keeps its limits as float-vectors, which
+    # the dump writes as null because they are not numbers. There is no 1-DOF
+    # URDF joint to map such a joint onto: a free one is URDF's "floating", and
+    # anything else -- including the immovable 6dof joint urdf2eus leaves at a
+    # model's root -- is honestly just a fixed connection.
+    if min_v is None or max_v is None:
+        if joint["movable"] and "6dof" in jtype:
+            return "floating"
+        return "fixed"
+
     inf = abs(min_v) >= _INF_LIMIT or abs(max_v) >= _INF_LIMIT
 
     # Fixed joints are emitted by urdf2eus as rotational-joints with 0/0
@@ -679,6 +690,12 @@ def movable_joint_spec(data):
         if not joint["movable"]:
             continue
         jtype = _classify_joint(joint, joint["name"] in follower)
+        if jtype not in ("revolute", "continuous", "prismatic"):
+            # A multi-DOF joint carries a vector, which no single scale factor
+            # describes and no URDF joint here can be driven by. EusLisp's
+            # eus2urdf-movable-joints leaves the same ones out, which is what
+            # keeps the two lists index-aligned.
+            continue
         scale = (1.0 / meter2millimeter) if jtype == "prismatic" \
             else float(np.pi / 180.0)
         spec.append((joint_unames[i], scale))

--- a/urdfeus/euslisp/eus2urdf-dump.l
+++ b/urdfeus/euslisp/eus2urdf-dump.l
@@ -81,7 +81,11 @@
   (let ((ax (j . axis)))
     (cond
       ((derivedp ax float-vector) ax)
-      ((listp ax) (coerce ax float-vector))
+      ;; A multi-DOF joint lists one entry per degree of freedom -- a
+      ;; sphere-joint carries (:x :y :z) -- and no single axis describes it,
+      ;; so say so rather than coercing keywords into a float-vector, which
+      ;; fails with "number expected".
+      ((listp ax) (if (every #'numberp ax) (coerce ax float-vector) nil))
       ((keywordp ax)
        (case ax
          (:x (float-vector 1 0 0)) (:-x (float-vector -1 0 0))
@@ -321,10 +325,20 @@
   ;; cascaded-coords objects are coordinate-only spots (door-spot, etc).
   (and (derivedp o cascaded-link) (send o :links)))
 
+(defun zero-joint (j)
+  ;; Set a joint to zero whatever its degrees of freedom. A 6dof-joint or a
+  ;; sphere-joint holds its value as a float-vector and rejects a scalar with
+  ;; "float vector expected", which is fatal, so match the shape of whatever
+  ;; the joint currently reports.
+  (let ((v (send j :joint-angle)))
+    (if (float-vector-p v)
+        (send j :joint-angle (instantiate float-vector (length v)))
+        (send j :joint-angle 0))))
+
 (defun dump-robot (r)
   (let (root all-links all-joints)
     ;; zero all movable joints so link world transforms give URDF joint origins
-    (dolist (j (send r :joint-list)) (send j :joint-angle 0))
+    (dolist (j (send r :joint-list)) (zero-joint j))
     (send r :worldcoords)
     (setq *movable-joints* (send r :joint-list))
     ;; Walk up to the true root in case (car links) is not it: climb while the
@@ -333,9 +347,15 @@
     (while (and (send root :parent) (derivedp (send root :parent) bodyset-link))
       (setq root (send root :parent)))
     (setq all-links (collect-all-links root))
-    ;; every non-root link contributes its parent joint (covers fixed joints too)
+    ;; every non-root link contributes its parent joint (covers fixed joints too),
+    ;; but only where the parent link is being dumped as well. The root's own
+    ;; joint can reach above the tree -- a 6dof joint tying the model to a
+    ;; virtual link, say -- and emitting it would name a parent that appears in
+    ;; no link, leaving the reader to look up a link that is not there.
     (setq all-joints
-          (remove nil (mapcar #'(lambda (l) (send l :joint)) all-links)))
+          (remove-if-not
+           #'(lambda (j) (memq (send j :parent-link) all-links))
+           (remove nil (mapcar #'(lambda (l) (send l :joint)) all-links))))
     (setq *out* (open *eus2urdf-out-path* :direction :output))
     (format *out* "{")
     (format *out* "\"robot_name\":") (pj-str (send r :name))
@@ -369,7 +389,7 @@
     ;; zero every physical object's movable joints
     (dolist (o objs)
       (when (scene-physical-p o)
-        (dolist (j (send o :joint-list)) (send j :joint-angle 0))))
+        (dolist (j (send o :joint-list)) (zero-joint j))))
     (send r :worldcoords)
     (setq *movable-joints*
           (apply #'append
@@ -509,7 +529,12 @@
     ((and (find-method obj :links) (send obj :links))
      (let ((jl (send obj :joint-list)))
        (remove-if-not
-        #'(lambda (j) (memq j jl))
+        ;; Multi-DOF joints are left out: their value is a float-vector, URDF
+        ;; has no single-DOF joint to carry them, and eus2urdf drops them to
+        ;; fixed. Excluding them here keeps this list index-aligned with the
+        ;; movable joints movable_joint_spec reports on the Python side.
+        #'(lambda (j) (and (memq j jl)
+                           (not (float-vector-p (send j :joint-angle)))))
         (remove nil (mapcar #'(lambda (l) (send l :joint))
                             (collect-all-links (object-root obj)))))))
     (t nil)))


### PR DESCRIPTION
A model carrying a sphere or 6dof joint could not be converted at all: zeroing passed a scalar to a joint whose value is a float-vector (fatal to irteusgl), a sphere joint's axis `(:x :y :z)` would not coerce to a float-vector, its vector limits dump as null and `_classify_joint` raised on `abs(None)`, and the root's own joint can name a parent link that is not in the dump.

Zero a joint to match the shape it reports, report no axis where no single axis exists, classify limitless joints as floating or fixed, and emit only joints whose parent is dumped too. Multi-DOF joints are left out of the movable-joint lists on both sides, keeping them index-aligned.

Converts jskeus' `closed-loop` and `look-at-ik` demos, neither of which got through before.